### PR TITLE
Make shared examples available from the .gem

### DIFF
--- a/lib/glimr_api_client/version.rb
+++ b/lib/glimr_api_client/version.rb
@@ -1,3 +1,3 @@
 module GlimrApiClient
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/lib/tasks/spec_setup.rake
+++ b/lib/tasks/spec_setup.rake
@@ -3,8 +3,7 @@ namespace :glimr_api_client do
   task :install_shared_examples
     source = File.join(
       Gem.loaded_specs['glimr-api-client'].full_gem_path,
-      'spec',
-      'support',
+      'shared_examples',
       'shared_examples_for_glimr.rb'
     )
     target = File.join(Rails.root, 'spec', 'support', 'shared_examples_for_glimr.rb')

--- a/shared_examples/shared_examples_for_glimr.rb
+++ b/shared_examples/shared_examples_for_glimr.rb
@@ -1,0 +1,212 @@
+RSpec.shared_examples 'glimr availability request' do |glimr_response|
+  before do
+    Excon.stub(
+      { host: 'glimr-test.dsd.io', path: '/glimravailable' },
+      status: 200, body: glimr_response.to_json
+    )
+  end
+end
+
+RSpec.shared_examples 'glimr availability request returns a 500' do
+  before do
+    Excon.stub(
+      { host: 'glimr-test.dsd.io', path: '/glimravailable' },
+      status: 500
+    )
+  end
+end
+
+RSpec.shared_examples 'service is not available' do
+  scenario do
+    visit '/'
+    expect(page).not_to have_text('Start now')
+    expect(page).to have_text('The service is currently unavailable')
+  end
+end
+
+RSpec.shared_examples 'generic glimr response' do |case_number, _confirmation_code, status, glimr_response|
+  before do
+    Excon.stub(
+      {
+        host: 'glimr-test.dsd.io',
+        body: /caseNumber=#{CGI.escape(case_number)}/,
+        path: '/requestpayablecasefees'
+      },
+      status: status, body: glimr_response.to_json
+    )
+  end
+end
+
+RSpec.shared_examples 'case not found' do
+  before do
+    Excon.stub(
+      {
+        host: 'glimr-test.dsd.io',
+        path: '/requestpayablecasefees'
+      },
+      status: 404
+    )
+  end
+end
+
+RSpec.shared_examples 'no new fees are due' do |case_number, _confirmation_code|
+  let(:response_body) {
+    {
+      'jurisdictionId' => 8,
+      'tribunalCaseId' => 60_029,
+      'caseTitle' => 'You vs HM Revenue & Customs',
+      'feeLiabilities' => []
+    }
+  }
+
+  before do
+    Excon.stub(
+      {
+        host: 'glimr-test.dsd.io',
+        body: /caseNumber=#{CGI.escape(case_number)}/,
+        path: '/requestpayablecasefees'
+      },
+      status: 200, body: response_body.to_json
+    )
+  end
+end
+
+RSpec.shared_examples 'a case fee of £20 is due' do |case_number, _confirmation_code|
+  let(:response_body) {
+    {
+      'jurisdictionId' => 8,
+      'tribunalCaseId' => 60_029,
+      'caseTitle' => 'You vs HM Revenue & Customs',
+      'feeLiabilities' =>
+      [{ 'feeLiabilityId' => '7',
+         'onlineFeeTypeDescription' => 'Lodgement Fee',
+         'payableWithUnclearedInPence' => '2000' }]
+    }.to_json
+  }
+
+  before do
+    Excon.stub(
+      {
+        method: :post,
+        host: 'glimr-test.dsd.io',
+        body: /caseNumber=#{CGI.escape(case_number)}&jurisdictionId=8/,
+        path: '/requestpayablecasefees'
+      },
+      status: 200, body: response_body
+    )
+  end
+end
+
+RSpec.shared_examples 'no fees then a £20 fee' do |case_number, _confirmation_code|
+  let(:no_fees) {
+    {
+      'jurisdictionId' => 8,
+      'tribunalCaseId' => 60_029,
+      'caseTitle' => 'You vs HM Revenue & Customs',
+      'feeLiabilities' => []
+    }
+  }
+
+  let(:twenty_pound_fee) {
+    {
+      'jurisdictionId' => 8,
+      'tribunalCaseId' => 60_029,
+      'caseTitle' => 'You vs HM Revenue & Customs',
+      'feeLiabilities' =>
+      [{ 'feeLiabilityId' => 7,
+         'onlineFeeTypeDescription' => 'Lodgement Fee',
+         'payableWithUnclearedInPence' => 2000 }]
+    }
+  }
+
+  before do
+    Excon.stub(
+      {
+        method: :post,
+        host: 'glimr-test.dsd.io',
+        body: /caseNumber=#{CGI.escape(case_number)}/,
+        path: '/requestpayablecasefees'
+      },
+      status: 200, body: no_fees.to_json
+    )
+
+    Excon.stub(
+      {
+        method: :post,
+        host: 'glimr-test.dsd.io',
+        body: /caseNumber=#{CGI.escape(case_number)}/,
+        path: '/requestpayablecasefees'
+      },
+      status: 200, body: twenty_pound_fee.to_json
+    )
+  end
+end
+
+RSpec.shared_examples 'report payment taken to glimr' do |req_body|
+  let(:paymenttaken_response) {
+    {
+      feeLiabilityId: 1234,
+      feeTransactionId: 1234,
+      paidAmountInPence: 9999
+    }
+  }
+
+  before do
+    Excon.stub(
+      {
+        method: :post,
+        host: 'glimr-test.dsd.io',
+        body: req_body,
+        path: '/paymenttaken'
+      },
+      status: 200, body: paymenttaken_response.to_json
+    )
+  end
+end
+
+RSpec.shared_examples 'glimr fee_paid returns a 500' do
+  before do
+    Excon.stub(
+      {
+        method: :post,
+        host: 'glimr-test.dsd.io',
+        path: '/paymenttaken'
+      },
+      status: 500
+    )
+  end
+end
+
+RSpec.shared_examples 'glimr times out' do
+  let(:glimr_check) {
+    class_double(Excon, 'glimr availability')
+  }
+
+  before do
+    expect(glimr_check).
+      to receive(:post).
+      with(path: '/glimravailable', body: '').
+      and_raise(Excon::Errors::Timeout)
+
+    expect(Excon).to receive(:new).
+      with(Rails.configuration.glimr_api_url, anything).
+      and_return(glimr_check)
+  end
+end
+
+RSpec.shared_examples 'glimr has a socket error' do
+  let(:glimr_check) {
+    class_double(Excon, 'glimr availability')
+  }
+
+  before do
+    expect(glimr_check).
+      to receive(:post).
+      with(path: '/glimravailable', body: '').
+      and_raise(Excon::Errors::SocketError)
+
+    expect(Excon).to receive(:new).
+      with('https://glimr-test.dsd.io', anything).
+      and_return(glimr_check)
+  end
+end


### PR DESCRIPTION
Specs aren't included in the .gem, so I had to yank version 0.1.0 of the gem as it was throwing rake errors as soon as you tried to run rake.  This fixes that (and version 0.1.1 of the gem has already been published to rubygems for testing purposes—I'll leave it as it works).

Will do the missing mutation tests in a separate branch/PR from master.   