### PR TITLE
New live path for glimr

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,11 @@
 PATH
   remote: .
   specs:
-    glimr-api-client (0.1.4)
+    glimr-api-client (0.1.5)
       activesupport (~> 5.0)
+      addressable (~> 2.4)
       excon (~> 0.51)
+      excon-addressable (~> 0.3)
 
 GEM
   remote: https://rubygems.org/
@@ -77,6 +79,9 @@ GEM
     equalizer (0.0.11)
     erubis (2.7.0)
     excon (0.54.0)
+    excon-addressable (0.3.1)
+      addressable (~> 2.3)
+      excon (~> 0.49)
     fuubar (2.0.0)
       rspec (~> 3.0)
       ruby-progressbar (~> 1.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,9 @@
 PATH
   remote: .
   specs:
-    glimr-api-client (0.1.5)
+    glimr-api-client (0.1.6)
       activesupport (~> 5.0)
-      addressable (~> 2.4)
       excon (~> 0.51)
-      excon-addressable (~> 0.3)
 
 GEM
   remote: https://rubygems.org/
@@ -79,9 +77,6 @@ GEM
     equalizer (0.0.11)
     erubis (2.7.0)
     excon (0.54.0)
-    excon-addressable (0.3.1)
-      addressable (~> 2.3)
-      excon (~> 0.49)
     fuubar (2.0.0)
       rspec (~> 3.0)
       ruby-progressbar (~> 1.4)

--- a/glimr_api_client.gemspec
+++ b/glimr_api_client.gemspec
@@ -27,7 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'sqlite3', '~> 1.3'
 
   spec.add_dependency 'excon', '~> 0.51'
-  spec.add_dependency 'excon-addressable', '~> 0.3'
-  spec.add_dependency 'addressable', '~> 2.4'
   spec.add_dependency 'activesupport', '~> 5.0'
 end

--- a/glimr_api_client.gemspec
+++ b/glimr_api_client.gemspec
@@ -27,5 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'sqlite3', '~> 1.3'
 
   spec.add_dependency 'excon', '~> 0.51'
+  spec.add_dependency 'excon-addressable', '~> 0.3'
+  spec.add_dependency 'addressable', '~> 2.4'
   spec.add_dependency 'activesupport', '~> 5.0'
 end

--- a/lib/glimr_api_client.rb
+++ b/lib/glimr_api_client.rb
@@ -1,3 +1,4 @@
+require 'json'
 require 'glimr_api_client/version'
 require 'glimr_api_client/api'
 require 'glimr_api_client/available'

--- a/lib/glimr_api_client/api.rb
+++ b/lib/glimr_api_client/api.rb
@@ -4,13 +4,18 @@ require 'active_support/core_ext/object/to_query'
 
 module GlimrApiClient
   module Api
+    DEFAULT_ENDPOINT =
+      ENV.fetch(
+        'GLIMR_API_URL',
+        'https://glimr-api.taxtribunals.dsd.io/Live_API/api/tdsapi'
+    )
+
     def post
-      @post ||=
-        client.post(path: endpoint, body: request_body.to_query).tap { |resp|
-          # Only timeouts and network issues raise errors.
-          handle_response_errors(resp)
-          @body = resp.body
-        }
+      client("#{DEFAULT_ENDPOINT}#{endpoint}").post(body: request_body.to_query).tap { |resp|
+        # Only timeouts and network issues raise errors.
+        handle_response_errors(resp)
+        @body = resp.body
+      }
     rescue Excon::Error => e
       if endpoint.eql?('/paymenttaken')
         raise PaymentNotificationFailure, e
@@ -37,14 +42,14 @@ module GlimrApiClient
       end
     end
 
-    def client
-      @client ||= Excon.new(
-        ENV.fetch('GLIMR_API_URL', 'https://glimr-test.dsd.io'),
+    def client(uri)
+      Excon.new(
+        uri,
         headers: {
-          'Content-Type' => 'application/json',
-          'Accept' => 'application/json'
-        },
-        persistent: true
+        'Content-Type' => 'application/json',
+        'Accept' => 'application/json'
+      },
+      persistent: true
       )
     end
   end

--- a/lib/glimr_api_client/version.rb
+++ b/lib/glimr_api_client/version.rb
@@ -1,3 +1,3 @@
 module GlimrApiClient
-  VERSION = '0.1.5'
+  VERSION = '0.1.6'
 end

--- a/spec/glimr_api_client/api_spec.rb
+++ b/spec/glimr_api_client/api_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe GlimrApiClient::Api, '#post' do
         method: :post,
         body: 'parameter=parameter',
         headers: {
-        "Content-Type" => "application/json",
-        "Accept" => "application/json"
-      },
-      path: '/endpoint',
+          "Content-Type" => "application/json",
+          "Accept" => "application/json"
+        },
+      path: '/Live_API/api/tdsapi/endpoint',
       persistent: true
       },
       status: 200, body: { response: 'response' }.to_json
@@ -29,7 +29,7 @@ RSpec.describe GlimrApiClient::Api, '#post' do
       Excon.stub(
         {
           method: :post,
-          path: '/endpoint',
+          path: '/Live_API/api/tdsapi/endpoint'
         },
         status: 404
       )
@@ -40,7 +40,7 @@ RSpec.describe GlimrApiClient::Api, '#post' do
       Excon.stub(
         {
           method: :post,
-          path: '/endpoint',
+          path: '/Live_API/api/tdsapi/endpoint'
         },
         status: 500
       )
@@ -51,7 +51,7 @@ RSpec.describe GlimrApiClient::Api, '#post' do
       Excon.stub(
         {
           method: :post,
-          path: '/endpoint',
+          path: '/Live_API/api/tdsapi/endpoint'
         },
         status: 400
       )
@@ -62,7 +62,7 @@ RSpec.describe GlimrApiClient::Api, '#post' do
       Excon.stub(
         {
           method: :post,
-          path: '/endpoint',
+          path: '/Live_API/api/tdsapi/endpoint'
         },
         status: 399
       )
@@ -73,7 +73,7 @@ RSpec.describe GlimrApiClient::Api, '#post' do
       Excon.stub(
         {
           method: :post,
-          path: '/endpoint',
+          path: '/Live_API/api/tdsapi/endpoint'
         },
         status: 600
       )
@@ -84,7 +84,7 @@ RSpec.describe GlimrApiClient::Api, '#post' do
       Excon.stub(
         {
           method: :post,
-          path: '/endpoint',
+          path: '/Live_API/api/tdsapi/endpoint'
         },
         status: 599
       )
@@ -97,7 +97,7 @@ RSpec.describe GlimrApiClient::Api, '#post' do
         Excon.stub(
           {
             method: :post,
-            path: '/paymenttaken',
+            path: '/Live_API/api/tdsapi/paymenttaken'
           },
           status: 399
         )
@@ -108,7 +108,7 @@ RSpec.describe GlimrApiClient::Api, '#post' do
         Excon.stub(
           {
             method: :post,
-            path: '/paymenttaken',
+            path: '/Live_API/api/tdsapi/paymenttaken'
           },
           status: 600
         )
@@ -119,7 +119,7 @@ RSpec.describe GlimrApiClient::Api, '#post' do
         Excon.stub(
           {
             method: :post,
-            path: '/paymenttaken',
+            path: '/Live_API/api/tdsapi/paymenttaken'
           },
           status: 404
         )
@@ -130,7 +130,7 @@ RSpec.describe GlimrApiClient::Api, '#post' do
         Excon.stub(
           {
             method: :post,
-            path: '/paymenttaken',
+            path: '/Live_API/api/tdsapi/paymenttaken'
           },
           status: 500
         )

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,10 @@ RSpec.configure do |config|
   config.before(:each) do
     I18n.locale = I18n.default_locale
     Excon.stub(
-      { host: 'glimr-test.dsd.io', path: '/glimravailable' },
+      {
+        host: 'glimr-api.taxtribunals.dsd.io',
+        path: '/Live_API/api/tdsapi/glimravailable'
+      },
       { status: 200, body: { glimrAvailable: 'yes' }.to_json }
     )
   end

--- a/spec/support/shared_examples_for_glimr.rb
+++ b/spec/support/shared_examples_for_glimr.rb
@@ -1,7 +1,10 @@
 RSpec.shared_examples 'glimr availability request' do |glimr_response|
   before do
     Excon.stub(
-      { host: 'glimr-test.dsd.io', path: '/glimravailable' },
+      {
+        host: 'glimr-api.taxtribunals.dsd.io',
+        path: '/Live_API/api/tdsapi/glimravailable'
+      },
       status: 200, body: glimr_response.to_json
     )
   end
@@ -10,7 +13,10 @@ end
 RSpec.shared_examples 'glimr availability request returns a 500' do
   before do
     Excon.stub(
-      { host: 'glimr-test.dsd.io', path: '/glimravailable' },
+      {
+        host: 'glimr-api.taxtribunals.dsd.io',
+        path: '/Live_API/api/tdsapi/glimravailable'
+      },
       status: 500
     )
   end
@@ -28,9 +34,9 @@ RSpec.shared_examples 'generic glimr response' do |case_number, _confirmation_co
   before do
     Excon.stub(
       {
-        host: 'glimr-test.dsd.io',
+        host: 'glimr-api.taxtribunals.dsd.io',
         body: /caseNumber=#{CGI.escape(case_number)}/,
-        path: '/requestpayablecasefees'
+        path: '/Live_API/api/tdsapi/requestpayablecasefees'
       },
       status: status, body: glimr_response.to_json
     )
@@ -41,8 +47,8 @@ RSpec.shared_examples 'case not found' do
   before do
     Excon.stub(
       {
-        host: 'glimr-test.dsd.io',
-        path: '/requestpayablecasefees'
+        host: 'glimr-api.taxtribunals.dsd.io',
+        path: '/Live_API/api/tdsapi/requestpayablecasefees'
       },
       status: 404
     )
@@ -62,9 +68,9 @@ RSpec.shared_examples 'no new fees are due' do |case_number, _confirmation_code|
   before do
     Excon.stub(
       {
-        host: 'glimr-test.dsd.io',
+        host: 'glimr-api.taxtribunals.dsd.io',
         body: /caseNumber=#{CGI.escape(case_number)}/,
-        path: '/requestpayablecasefees'
+        path: '/Live_API/api/tdsapi/requestpayablecasefees'
       },
       status: 200, body: response_body.to_json
     )
@@ -88,9 +94,9 @@ RSpec.shared_examples 'a case fee of £20 is due' do |case_number, _confirmation
     Excon.stub(
       {
         method: :post,
-        host: 'glimr-test.dsd.io',
+        host: 'glimr-api.taxtribunals.dsd.io',
         body: /caseNumber=#{CGI.escape(case_number)}&jurisdictionId=8/,
-        path: '/requestpayablecasefees'
+        path: '/Live_API/api/tdsapi/requestpayablecasefees'
       },
       status: 200, body: response_body
     )
@@ -123,9 +129,9 @@ RSpec.shared_examples 'no fees then a £20 fee' do |case_number, _confirmation_c
     Excon.stub(
       {
         method: :post,
-        host: 'glimr-test.dsd.io',
+        host: 'glimr-api.taxtribunals.dsd.io',
         body: /caseNumber=#{CGI.escape(case_number)}/,
-        path: '/requestpayablecasefees'
+        path: '/Live_API/api/tdsapi/requestpayablecasefees'
       },
       status: 200, body: no_fees.to_json
     )
@@ -133,9 +139,9 @@ RSpec.shared_examples 'no fees then a £20 fee' do |case_number, _confirmation_c
     Excon.stub(
       {
         method: :post,
-        host: 'glimr-test.dsd.io',
+        host: 'glimr-api.taxtribunals.dsd.io',
         body: /caseNumber=#{CGI.escape(case_number)}/,
-        path: '/requestpayablecasefees'
+        path: '/Live_API/api/tdsapi/requestpayablecasefees'
       },
       status: 200, body: twenty_pound_fee.to_json
     )
@@ -155,9 +161,9 @@ RSpec.shared_examples 'report payment taken to glimr' do |req_body|
     Excon.stub(
       {
         method: :post,
-        host: 'glimr-test.dsd.io',
+        host: 'glimr-api.taxtribunals.dsd.io',
         body: req_body,
-        path: '/paymenttaken'
+        path: '/Live_API/api/tdsapi/paymenttaken'
       },
       status: 200, body: paymenttaken_response.to_json
     )
@@ -169,8 +175,8 @@ RSpec.shared_examples 'glimr fee_paid returns a 500' do
     Excon.stub(
       {
         method: :post,
-        host: 'glimr-test.dsd.io',
-        path: '/paymenttaken'
+        host: 'glimr-api.taxtribunals.dsd.io',
+        path: '/Live_API/api/tdsapi/paymenttaken'
       },
       status: 500
     )
@@ -180,12 +186,12 @@ end
 RSpec.shared_examples 'glimr times out' do
   let(:glimr_check) {
     class_double(Excon, 'glimr availability')
-  }
+  requestpayablecasefees}
 
   before do
     expect(glimr_check).
       to receive(:post).
-      with(path: '/glimravailable', body: '').
+      with(path: '/Live_API/api/tdsapi/glimravailable', body: '').
       and_raise(Excon::Errors::Timeout)
 
     expect(Excon).to receive(:new).
@@ -202,11 +208,11 @@ RSpec.shared_examples 'glimr has a socket error' do
   before do
     expect(glimr_check).
       to receive(:post).
-      with(path: '/glimravailable', body: '').
+      with(body: '').
       and_raise(Excon::Errors::SocketError)
 
     expect(Excon).to receive(:new).
-      with('https://glimr-test.dsd.io', anything).
+      with('https://glimr-api.taxtribunals.dsd.io/Live_API/api/tdsapi/glimravailable', anything).
       and_return(glimr_check)
   end
 end


### PR DESCRIPTION
This is the simplest possible solution to problem that resulted when Christian discovered that a properly-configured glimr api does not answer api calls on the root endpoint.