### PR TITLE
remove 'blank?' & bump gem version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    glimr-api-client (0.1.7)
+    glimr-api-client (0.1.8)
       activesupport (~> 5.0)
       excon (~> 0.51)
 

--- a/lib/glimr_api_client/register_new_case.rb
+++ b/lib/glimr_api_client/register_new_case.rb
@@ -12,9 +12,9 @@ module GlimrApiClient
         :jurisdictionId,
         :onlineMappingCode
       ].each do |required|
-        errors << required if request_body.key?(required).blank?
+        errors << required if request_body.fetch(required, nil).nil?
       end
-      raise RequestError, errors unless errors.blank?
+      raise RequestError, errors unless errors.empty?
     end
 
     def endpoint

--- a/lib/glimr_api_client/version.rb
+++ b/lib/glimr_api_client/version.rb
@@ -1,3 +1,3 @@
 module GlimrApiClient
-  VERSION = '0.1.7'
+  VERSION = '0.1.8'
 end


### PR DESCRIPTION
blank? is a railsism, so it breaks non-rails uses
of the gem