### PR TITLE
Prevent integration tests from breaking

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    glimr-api-client (0.1.9)
+    glimr-api-client (0.1.10)
       activesupport (~> 5.0)
       excon (~> 0.51)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    glimr-api-client (0.1.8)
+    glimr-api-client (0.1.9)
       activesupport (~> 5.0)
       excon (~> 0.51)
 

--- a/lib/glimr_api_client/api.rb
+++ b/lib/glimr_api_client/api.rb
@@ -4,14 +4,8 @@ require 'active_support/core_ext/object/to_query'
 
 module GlimrApiClient
   module Api
-    DEFAULT_ENDPOINT =
-      ENV.fetch(
-        'GLIMR_API_URL',
-        'https://glimr-api.taxtribunals.dsd.io/Live_API/api/tdsapi'
-    )
-
     def post
-      client("#{DEFAULT_ENDPOINT}#{endpoint}").post(body: request_body.to_query).tap { |resp|
+      client("#{api_url}#{endpoint}").post(body: request_body.to_query).tap { |resp|
         # Only timeouts and network issues raise errors.
         handle_response_errors(resp)
         @body = resp.body
@@ -25,6 +19,14 @@ module GlimrApiClient
     end
 
     private
+
+    # If this is set using a constant, and the gem is included in a project
+    # that uses the dotenv gem, then it will always fall through to the default
+    # unless dotenv is included and required before this gem is loaded.
+    def api_url
+      ENV.fetch('GLIMR_API_URL',
+                'https://glimr-api.taxtribunals.dsd.io/Live_API/api/tdsapi')
+    end
 
     def handle_response_errors(resp)
       if (!endpoint.eql?('/paymenttaken') && resp.status.equal?(404))
@@ -49,10 +51,10 @@ module GlimrApiClient
       Excon.new(
         uri,
         headers: {
-          'Content-Type' => 'application/json',
-          'Accept' => 'application/json'
-        },
-        persistent: true
+        'Content-Type' => 'application/json',
+        'Accept' => 'application/json'
+      },
+      persistent: true
       )
     end
   end

--- a/lib/glimr_api_client/api.rb
+++ b/lib/glimr_api_client/api.rb
@@ -51,9 +51,9 @@ module GlimrApiClient
       Excon.new(
         uri,
         headers: {
-        'Content-Type' => 'application/json',
-        'Accept' => 'application/json'
-      },
+          'Content-Type' => 'application/json',
+          'Accept' => 'application/json'
+        },
       persistent: true
       )
     end

--- a/lib/glimr_api_client/version.rb
+++ b/lib/glimr_api_client/version.rb
@@ -1,3 +1,3 @@
 module GlimrApiClient
-  VERSION = '0.1.8'
+  VERSION = '0.1.9'
 end

--- a/lib/glimr_api_client/version.rb
+++ b/lib/glimr_api_client/version.rb
@@ -1,3 +1,3 @@
 module GlimrApiClient
-  VERSION = '0.1.9'
+  VERSION = '0.1.10'
 end


### PR DESCRIPTION
The `DEFAULT_URL` constant wasn't picking up the value of
`GLIMR_API_URL` when the gem was being run in integration tests in
`tax-tribunals-fees`.  This was because the `dotenv` gem had to be
loaded and required prior to the `glimr-api-client` gem. In order to
avoid doing this, I have changed the constant to a method that fetches
the value when it is called.