### PR TITLE
get Case Title from the first fee liability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    glimr-api-client (0.1.12)
+    glimr-api-client (0.1.13)
       excon (~> 0.51)
 
 GEM

--- a/lib/glimr_api_client/case.rb
+++ b/lib/glimr_api_client/case.rb
@@ -19,7 +19,19 @@ module GlimrApiClient
     end
 
     def title
-      @title ||= response_body.fetch(:caseTitle)
+      # This should be;
+      #
+      #   @title ||= response_body.fetch(:caseTitle)
+      #
+      # But, a change in the Glimr API means that the title is
+      # currently being returned with each fee liability. So,
+      # for the time being, we will fetch it from there.
+      # I'm leaving the "Missing Title" text so that nobody forgets
+      # that this needs to be fixed, preferably by changing the
+      # Glimr RequestPayableCaseFees API call back to returning
+      # caseTitle at the top-level of the response data.
+
+      @title ||= fees.any? ? fees.first.case_title : "Missing Title"
     end
 
     def fees
@@ -27,7 +39,8 @@ module GlimrApiClient
         OpenStruct.new(
           glimr_id: Integer(fee.fetch(:feeLiabilityId)),
           description: fee.fetch(:onlineFeeTypeDescription),
-          amount: Integer(fee.fetch(:payableWithUnclearedInPence))
+          amount: Integer(fee.fetch(:payableWithUnclearedInPence)),
+          case_title: fee.fetch(:caseTitle)
         )
       end
     end

--- a/lib/glimr_api_client/version.rb
+++ b/lib/glimr_api_client/version.rb
@@ -1,3 +1,3 @@
 module GlimrApiClient
-  VERSION = '0.1.12'
+  VERSION = '0.1.13'
 end

--- a/spec/requests/case_spec.rb
+++ b/spec/requests/case_spec.rb
@@ -6,10 +6,8 @@ RSpec.describe GlimrApiClient::Case do
 
   subject { described_class.find('TT/2016/00001', 'ABC123') }
 
-  describe '#title' do
-    it 'returns the title' do
-      expect(subject.title).to eq('Missing Title')
-    end
+  it 'returns "Missing Title" when there are no fees' do
+    expect(subject.title).to eq('Missing Title')
   end
 end
 
@@ -18,10 +16,8 @@ RSpec.describe GlimrApiClient::Case do
 
   subject { described_class.find('TT/2016/00001', 'ABC123') }
 
-  describe '#title' do
-    it 'returns the title from the first fee' do
-      expect(subject.title).to eq('First Title')
-    end
+  it 'returns the title from the first fee' do
+    expect(subject.title).to eq('First Title')
   end
 end
 
@@ -35,10 +31,8 @@ RSpec.describe GlimrApiClient::Case do
 
   subject { described_class.find('TT/2016/00001', 'ABC123') }
 
-  describe '#title' do
-    it 'returns the title' do
-      expect(subject.title).to eq('You vs HM Revenue & Customs')
-    end
+  it 'returns the title' do
+    expect(subject.title).to eq('You vs HM Revenue & Customs')
   end
 
   describe '#fees' do

--- a/spec/requests/case_spec.rb
+++ b/spec/requests/case_spec.rb
@@ -2,6 +2,30 @@ require 'rails_helper'
 require 'support/shared_examples_for_glimr'
 
 RSpec.describe GlimrApiClient::Case do
+  include_examples 'no fees', 'TT/2016/00001', 'ABC123'
+
+  subject { described_class.find('TT/2016/00001', 'ABC123') }
+
+  describe '#title' do
+    it 'returns the title' do
+      expect(subject.title).to eq('Missing Title')
+    end
+  end
+end
+
+RSpec.describe GlimrApiClient::Case do
+  include_examples 'two fees', 'TT/2016/00001', 'ABC123'
+
+  subject { described_class.find('TT/2016/00001', 'ABC123') }
+
+  describe '#title' do
+    it 'returns the title from the first fee' do
+      expect(subject.title).to eq('First Title')
+    end
+  end
+end
+
+RSpec.describe GlimrApiClient::Case do
   include_examples 'a case fee of £20 is due', 'TT/2016/00001', 'ABC123'
 
   it 'requires two parameters' do
@@ -24,7 +48,8 @@ RSpec.describe GlimrApiClient::Case do
           OpenStruct.new(
             glimr_id: 7,
             description: 'Lodgement Fee',
-            amount: 2000
+            amount: 2000,
+            case_title: 'You vs HM Revenue & Customs'
           )
         ]
       )

--- a/spec/support/shared_examples_for_glimr.rb
+++ b/spec/support/shared_examples_for_glimr.rb
@@ -60,8 +60,9 @@ RSpec.shared_examples 'no new fees are due' do |case_number, _confirmation_code|
     {
       'jurisdictionId' => 8,
       'tribunalCaseId' => 60_029,
-      'caseTitle' => 'You vs HM Revenue & Customs',
-      'feeLiabilities' => []
+      'feeLiabilities' => [
+        'caseTitle' => 'You vs HM Revenue & Customs'
+      ]
     }
   }
 
@@ -82,9 +83,9 @@ RSpec.shared_examples 'a case fee of £20 is due' do |case_number, confirmation_
     {
       'jurisdictionId' => 8,
       'tribunalCaseId' => 60_029,
-      'caseTitle' => 'You vs HM Revenue & Customs',
       'feeLiabilities' =>
       [{ 'feeLiabilityId' => '7',
+         'caseTitle' => 'You vs HM Revenue & Customs',
          'onlineFeeTypeDescription' => 'Lodgement Fee',
          'payableWithUnclearedInPence' => '2000' }]
     }.to_json
@@ -104,25 +105,20 @@ RSpec.shared_examples 'a case fee of £20 is due' do |case_number, confirmation_
   end
 end
 
-RSpec.shared_examples 'no fees then a £20 fee' do |case_number, _confirmation_code|
+RSpec.shared_examples 'two fees' do |case_number, _confirmation_code|
   let(:no_fees) {
     {
       'jurisdictionId' => 8,
       'tribunalCaseId' => 60_029,
-      'caseTitle' => 'You vs HM Revenue & Customs',
-      'feeLiabilities' => []
-    }
-  }
-
-  let(:twenty_pound_fee) {
-    {
-      'jurisdictionId' => 8,
-      'tribunalCaseId' => 60_029,
-      'caseTitle' => 'You vs HM Revenue & Customs',
       'feeLiabilities' =>
-      [{ 'feeLiabilityId' => 7,
+      [{ 'feeLiabilityId' => '7',
+         'caseTitle' => 'First Title',
          'onlineFeeTypeDescription' => 'Lodgement Fee',
-         'payableWithUnclearedInPence' => 2000 }]
+         'payableWithUnclearedInPence' => '2000' },
+       { 'feeLiabilityId' => '7',
+         'caseTitle' => 'Second Title',
+         'onlineFeeTypeDescription' => 'Another Fee',
+         'payableWithUnclearedInPence' => '2000' }]
     }
   }
 
@@ -131,20 +127,32 @@ RSpec.shared_examples 'no fees then a £20 fee' do |case_number, _confirmation_c
       {
         method: :post,
         host: 'glimr-api.taxtribunals.dsd.io',
-        body: /caseNumber=#{CGI.escape(case_number)}/,
+        body: "{\"jurisdictionId\":8,\"caseNumber\":\"#{case_number}\",\"confirmationCode\":\"ABC123\"}",
         path: '/Live_API/api/tdsapi/requestpayablecasefees'
       },
       status: 200, body: no_fees.to_json
     )
+  end
+end
 
+RSpec.shared_examples 'no fees' do |case_number, _confirmation_code|
+  let(:no_fees) {
+    {
+      'jurisdictionId' => 8,
+      'tribunalCaseId' => 60_029,
+      'feeLiabilities' => []
+    }
+  }
+
+  before do
     Excon.stub(
       {
         method: :post,
         host: 'glimr-api.taxtribunals.dsd.io',
-        body: /caseNumber=#{CGI.escape(case_number)}/,
+        body: "{\"jurisdictionId\":8,\"caseNumber\":\"#{case_number}\",\"confirmationCode\":\"ABC123\"}",
         path: '/Live_API/api/tdsapi/requestpayablecasefees'
       },
-      status: 200, body: twenty_pound_fee.to_json
+      status: 200, body: no_fees.to_json
     )
   end
 end


### PR DESCRIPTION
This reflects a change in the Glimr API, which we
want them to revert. But, for now, we also want
the gem to work.