### PR TITLE
Stop exceptions when timeout is set

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    glimr-api-client (0.2.1)
+    glimr-api-client (0.2.2)
       excon (~> 0.51)
 
 GEM

--- a/lib/glimr_api_client/api.rb
+++ b/lib/glimr_api_client/api.rb
@@ -15,6 +15,10 @@ module GlimrApiClient
       @response_body ||= JSON.parse(@body, symbolize_names: true)
     end
 
+    def timeout 
+      Integer(ENV.fetch('GLIMR_API_TIMEOUT_SECONDS', 5))
+    end
+
     private
 
     # If this is set using a constant, and the gem is included in a project
@@ -50,7 +54,7 @@ module GlimrApiClient
           'Accept' => 'application/json'
         },
         persistent: true,
-        read_timeout: ENV.fetch('GLIMR_API_TIMEOUT_SECONDS', 5)
+        read_timeout: timeout 
       )
     end
   end

--- a/lib/glimr_api_client/version.rb
+++ b/lib/glimr_api_client/version.rb
@@ -1,3 +1,3 @@
 module GlimrApiClient
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end

--- a/spec/glimr_api_client/api_spec.rb
+++ b/spec/glimr_api_client/api_spec.rb
@@ -32,24 +32,29 @@ RSpec.describe GlimrApiClient::Api, '#post' do
     end
   end
 
-  it 'exposes an excon client' do
-    Excon.stub(
-      {
-        method: :post,
-        body: { parameter: "parameter" }.to_json,
-        headers: {
+  describe 'excon client' do
+    before do
+      Excon.stub(
+        {
+          method: :post,
+          body: { parameter: "parameter" }.to_json,
+          headers: {
           "Content-Type" => "application/json",
           "Accept" => "application/json"
         },
         path: path,
         persistent: true,
         read_timeout: 5
-      },
-      status: 200, body: { response: 'response' }.to_json
-    )
-    glimr_method_class.tap do |o|
-      expect { o.post }.not_to raise_error
-      expect(o.response_body).to eq({ response: 'response' })
+        },
+        status: 200, body: { response: 'response' }.to_json
+      )
+    end
+
+    it 'returns expected response' do
+      glimr_method_class.tap do |o|
+        expect { o.post }.not_to raise_error
+        expect(o.response_body).to eq({ response: 'response' })
+      end
     end
   end
 

--- a/spec/lib/api_spec.rb
+++ b/spec/lib/api_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe GlimrApiClient::Api do
+  # Required for run/build ordering in mutation tests.
+  subject do
+    Class.new do
+      include GlimrApiClient::Api
+    end.new
+  end
+
+  describe '#timeout' do
+    it 'sets a default timeout for the connection' do
+      expect(subject.timeout).to eq(5)
+    end
+
+    it 'allows overriding' do
+      allow(ENV).to receive(:fetch).with('GLIMR_API_TIMEOUT_SECONDS', 5).and_return(7)
+      expect(subject.timeout).to eq(7)
+    end
+
+    it 'does not error if override is a string' do
+      allow(ENV).to receive(:fetch).with('GLIMR_API_TIMEOUT_SECONDS', 5).and_return('7')
+      expect(subject.timeout).to eq(7)
+    end
+  end
+end


### PR DESCRIPTION
Environment variables are strings, of course...

This is slightly more convoluted than it might otherwise have been due
to the nature of the mutations arising around the original version.