### PR TITLE
Run specs and rubocop on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,8 @@
 language: ruby
+sudo: false
+cache:
+  bundler: true
+bundler_args: --jobs 3 --retry 3
+script:
+- bundle exec rubocop
+- bundle exec rspec


### PR DESCRIPTION
This PR instructs travis to run Rubocop and the Specs when creating Pull Requests to catch errors and code styling issues before the get merged.